### PR TITLE
Update mmgbsa_new.py

### DIFF
--- a/impress_md/mmgbsa_new.py
+++ b/impress_md/mmgbsa_new.py
@@ -25,7 +25,7 @@ def simulate(inpcrd_filenames, prmtop_filenames, niterations=1000, implicit=True
         integrator.setConstraintTolerance(0.00001)
         
         platform = mm.Platform.getPlatformByName('CUDA')
-        properties = {'CudaPrecision': 'mixed'}
+        properties = {'CudaPrecision': 'mixed', 'CudaDeviceIndex' : '0'}
         simulation = app.Simulation(prmtop.topology, system, integrator, platform, properties)
         simulation.context.setPositions(inpcrd.positions)
         
@@ -40,6 +40,9 @@ def simulate(inpcrd_filenames, prmtop_filenames, niterations=1000, implicit=True
             state = simulation.context.getState(getEnergy=True)
             potential_energy = state.getPotentialEnergy()
             enthalpies[phase][iteration] = potential_energy.value_in_unit(unit.kilojoules_per_mole)
+        del simulation
+        del system
+        del platform
     return enthalpies
 
 def subsample(enthalpies):


### PR DESCRIPTION
The problem, turns out, wasn’t GPU related or summit—a sneaky variable re-assignment which called a constructor before the assignees’ deconstructor. The pipeline had three simulations phases to run. Under the hood, platform.getPlatform(“CUDA”) wanted to create cuCtxCreate on a GPU that no one else was using. When that for loop got around to the next phase, platform.getPlatform was called without releasing the prior platoform, so if you wanted device 0, you’d get device one. On JSrun when we would give a resource group only a single gpu, this would result in a failure as there is not another gpu to use, and the only gpu was not released correctly.